### PR TITLE
feat: zip name in titlebar on macOS

### DIFF
--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -186,7 +186,7 @@ export class App extends React.Component<{}, Partial<AppState>> {
   public render(): JSX.Element {
     const { unzippedFiles, openEmpty } = this.state;
     const className = classNames('App', { Darwin: process.platform === 'darwin' });
-    const titleBar = process.platform === 'darwin' ? <MacTitlebar /> : '';
+    const titleBar = process.platform === 'darwin' ? <MacTitlebar state={this.sleuthState}/> : '';
     const content = unzippedFiles && (unzippedFiles.length || openEmpty)
       ? <CoreApplication state={this.sleuthState} unzippedFiles={unzippedFiles} />
       : <Welcome state={this.sleuthState} />;

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -16,6 +16,7 @@ import { shouldIgnoreFile } from '../../utils/should-ignore-file';
 import { isCacheDir } from '../../utils/is-cache';
 import { UnzippedFiles, UnzippedFile } from '../../interfaces';
 import { autorun } from 'mobx';
+import { getWindowTitle } from '../../utils/get-window-title';
 
 const debug = require('debug')('sleuth:app');
 
@@ -205,9 +206,7 @@ export class App extends React.Component<{}, Partial<AppState>> {
    */
   private setupWindowTitle() {
     autorun(() => {
-      document.title = this.sleuthState.source
-        ? `${path.basename(this.sleuthState.source)} - Sleuth`
-        : `Sleuth`;
+      document.title = getWindowTitle(this.sleuthState.source);
     });
   }
 

--- a/src/renderer/components/mac-titlebar.tsx
+++ b/src/renderer/components/mac-titlebar.tsx
@@ -1,3 +1,21 @@
 import React from 'react';
+import * as path from 'path';
+import { SleuthState } from '../state/sleuth';
 
-export const MacTitlebar = () => <div className='MacTitlebar' />;
+interface TitlebarProps {
+  state: SleuthState;
+}
+
+export class MacTitlebar extends React.Component<TitlebarProps> {
+  constructor(props: TitlebarProps) {
+    super(props);
+  }
+
+  render () {
+    const { source } = this.props.state;
+    const title = source
+    ? `${path.basename(source)} - Sleuth`
+    : `Sleuth`;
+    return <div className='MacTitlebar'><span>{title}</span></div>;
+  }
+}

--- a/src/renderer/components/mac-titlebar.tsx
+++ b/src/renderer/components/mac-titlebar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import * as path from 'path';
 import { SleuthState } from '../state/sleuth';
+import { getWindowTitle } from '../../utils/get-window-title';
 
 interface TitlebarProps {
   state: SleuthState;
@@ -13,9 +13,6 @@ export class MacTitlebar extends React.Component<TitlebarProps> {
 
   render () {
     const { source } = this.props.state;
-    const title = source
-    ? `${path.basename(source)} - Sleuth`
-    : `Sleuth`;
-    return <div className='MacTitlebar'><span>{title}</span></div>;
+    return <div className='MacTitlebar'><span>{getWindowTitle(source)}</span></div>;
   }
 }

--- a/src/renderer/styles/app.less
+++ b/src/renderer/styles/app.less
@@ -5,10 +5,6 @@
   padding: 0;
   overflow: hidden;
   box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
 
   h1,h2,h3,h4,h5,h6,p,span {
     user-select: none;

--- a/src/renderer/styles/mac-titlebar.less
+++ b/src/renderer/styles/mac-titlebar.less
@@ -1,9 +1,9 @@
 .MacTitlebar {
-  position: absolute;
-  left: 0px;
-  top: 0px;
   width: 100vw;
   height: 32px;
   -webkit-user-select: none;
   -webkit-app-region: drag;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/src/utils/get-window-title.ts
+++ b/src/utils/get-window-title.ts
@@ -1,0 +1,7 @@
+import * as path from 'path';
+
+export function getWindowTitle(source?: string) {
+  return source
+    ? `${path.basename(source)} — Sleuth`
+    : `Sleuth`;
+}

--- a/test/renderer/components/__snapshots__/mac-title-bar-test.tsx.snap
+++ b/test/renderer/components/__snapshots__/mac-title-bar-test.tsx.snap
@@ -3,5 +3,9 @@
 exports[`mac-titlebar renders correctly 1`] = `
 <div
   className="MacTitlebar"
-/>
+>
+  <span>
+    Sleuth
+  </span>
+</div>
 `;

--- a/test/renderer/components/mac-title-bar-test.tsx
+++ b/test/renderer/components/mac-title-bar-test.tsx
@@ -4,7 +4,7 @@ import renderer from 'react-test-renderer';
 
 it('mac-titlebar renders correctly', () => {
   const tree = renderer.create(
-    <MacTitlebar />
+    <MacTitlebar state={{} as any} />
   ).toJSON();
 
   expect(tree).toMatchSnapshot();


### PR DESCRIPTION
Also incidentally fixes the titlebar not rendering properly due misplaced flexbox rules.