### PR TITLE
fix: the launch protocol for Sleuth is not slack://

### DIFF
--- a/static/extend.plist
+++ b/static/extend.plist
@@ -7,7 +7,7 @@
       <dict>
         <key>CFBundleURLSchemes</key>
         <array>
-          <string>slack</string>
+          <string>sleuth</string>
         </array>
       </dict>
     </array>


### PR DESCRIPTION
As in title, the `sleuth://` protocol wasn't working correctly