### PR TITLE
fix: add selectAll menu item

### DIFF
--- a/src/main/menu-template.ts
+++ b/src/main/menu-template.ts
@@ -19,6 +19,8 @@ export function getMenuTemplate(options: MenuTemplateOptions) {
         }, {
           role: 'paste'
         }, {
+          role: 'selectAll'
+        }, {
           type: 'separator'
         }, {
           label: 'Find',


### PR DESCRIPTION
Seems like you're unable to use the <kbd>⌘</kbd> + <kbd>A</kbd> shortcut if the corresponding menu item doesn't exist.