### PR TITLE
feat: change `backtrace` to `sentry`

### DIFF
--- a/src/main/menu-template.ts
+++ b/src/main/menu-template.ts
@@ -119,9 +119,9 @@ export function getMenuTemplate(options: MenuTemplateOptions) {
       label: 'Utilities',
       submenu: [
         {
-          label: 'Open Backtrace',
+          label: 'Open Sentry',
           click(_item: Electron.MenuItem, browserWindow: BrowserWindow) {
-            browserWindow.webContents.send('open-backtrace');
+            browserWindow.webContents.send('open-sentry');
           }
         },
         { type: 'separator' },

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -10,7 +10,7 @@ import { CoreApplication } from './app-core';
 import { MacTitlebar } from './mac-titlebar';
 import { Preferences } from './preferences';
 import { sendWindowReady } from '../ipc';
-import { openBacktrace } from '../backtrace';
+import { openSentry } from '../sentry';
 import { SleuthState } from '../state/sleuth';
 import { shouldIgnoreFile } from '../../utils/should-ignore-file';
 import { isCacheDir } from '../../utils/is-cache';
@@ -52,7 +52,7 @@ export class App extends React.Component<{}, Partial<AppState>> {
 
     this.setupFileDrop();
     this.setupBusyResponse();
-    this.setupOpenBacktrace();
+    this.setupOpenSentry();
     this.setupWindowTitle();
   }
 
@@ -228,15 +228,15 @@ export class App extends React.Component<{}, Partial<AppState>> {
     ipcRenderer.on('file-dropped', (_event: any, url: string) => this.openFile(url));
   }
 
-  private setupOpenBacktrace() {
-    ipcRenderer.on('open-backtrace', () => {
+  private setupOpenSentry() {
+    ipcRenderer.on('open-sentry', () => {
       // Get the file path to the installation file. Only app-* classes know.
       const installationFile = this.state.unzippedFiles?.find((file) => {
         return (file.fileName === 'installation');
       });
 
       // Then, let the utility handle the details
-      openBacktrace(installationFile?.fullPath);
+      openSentry(installationFile?.fullPath);
     });
   }
 

--- a/src/renderer/components/state-table.tsx
+++ b/src/renderer/components/state-table.tsx
@@ -14,7 +14,7 @@ import { parseJSON } from '../../utils/parse-json';
 import { getFontForCSS } from './preferences-font';
 import { isTruthy } from '../../utils/is-truthy';
 import { plural } from '../../utils/pluralize';
-import { getBacktraceHref, convertInstallation } from '../backtrace';
+import { getSentryHref, convertInstallation } from '../sentry';
 
 const debug = require('debug')('sleuth:statetable');
 
@@ -272,11 +272,11 @@ export class StateTable extends React.Component<StateTableProps, StateTableState
 
     if (Array.isArray(data) && data.length > 0) {
       const id = convertInstallation(data[0]);
-      const href = getBacktraceHref(id);
+      const href = getSentryHref(id);
 
       return (
         <Card className='StateTable-Info'>
-          See exceptions in Backtrace: <a onClick={() => shell.openExternal(href)}>{id}</a>
+          See exceptions in Sentry: <a onClick={() => shell.openExternal(href)}>{id}</a>
         </Card>
       );
     }

--- a/src/renderer/sentry.ts
+++ b/src/renderer/sentry.ts
@@ -3,9 +3,9 @@ import fs from 'fs-extra';
 import { showMessageBox } from './ipc';
 import { shell } from 'electron';
 
-const debug = require('debug')('sleuth:backtrace');
+const debug = require('debug')('sleuth:sentry');
 
-export async function openBacktrace(installationFilePath?: string): Promise<void> {
+export async function openSentry(installationFilePath?: string): Promise<void> {
   // No file? Do nothing
   if (!installationFilePath) {
     showMessageBox({
@@ -22,10 +22,10 @@ export async function openBacktrace(installationFilePath?: string): Promise<void
     const id = convertInstallation(data);
 
     if (id) {
-      shell.openExternal(getBacktraceHref(id));
+      shell.openExternal(getSentryHref(id));
     }
   } catch (error) {
-    debug(`Failed to read backtrace link`);
+    debug(`Failed to read Sentry link`);
   }
 }
 
@@ -33,9 +33,6 @@ export function convertInstallation(data: string): string {
   return new Buffer(data, 'base64').toString('ascii');
 }
 
-export function getBacktraceHref(installationId: string) {
-  const base = `https://backtrace.tinyspeck.com/p/desktop/list?aperture=`;
-  const query = `[[%22relative%22,[%22floating%22,%22all%22]],[[%22instanceUid%22,[%22equal%22,%22${installationId}%22]]]]`;
-
-  return `${base}${query}`;
+export function getSentryHref(installationId: string) {
+  return `https://sentry.io/organizations/tinyspeck/issues/?project=5277886&query=is%3Aunresolved+uuid%3A${installationId}`;
 }


### PR DESCRIPTION
Since we've decommissioned Backtrace and now use https://sentry.io instead, this PR does a lot of renaming and ultimately changes the URL to our `sentry.io` instance.